### PR TITLE
Improve terminal UI with spinner and better console handling

### DIFF
--- a/src/cli_ui.cpp
+++ b/src/cli_ui.cpp
@@ -4,6 +4,8 @@
 #include <sstream>
 #include <filesystem>
 #include <algorithm>
+#include <thread>
+#include <atomic>
 
 namespace winuzzf {
 namespace cli {
@@ -25,7 +27,20 @@ TerminalUI::~TerminalUI() {
 }
 
 void TerminalUI::Clear() {
-    system("cls");
+    CONSOLE_SCREEN_BUFFER_INFO csbi;
+    DWORD count;
+    DWORD cell_count;
+    COORD home = {0, 0};
+
+    if (!GetConsoleScreenBufferInfo(console_handle_, &csbi)) {
+        system("cls");
+        return;
+    }
+
+    cell_count = csbi.dwSize.X * csbi.dwSize.Y;
+    FillConsoleOutputCharacter(console_handle_, ' ', cell_count, home, &count);
+    FillConsoleOutputAttribute(console_handle_, csbi.wAttributes, cell_count, home, &count);
+    SetConsoleCursorPosition(console_handle_, home);
 }
 
 void TerminalUI::HideCursor() {
@@ -45,6 +60,16 @@ void TerminalUI::ShowCursor() {
 void TerminalUI::SetCursorPosition(int x, int y) {
     COORD pos = { static_cast<SHORT>(x), static_cast<SHORT>(y) };
     SetConsoleCursorPosition(console_handle_, pos);
+}
+
+void TerminalUI::ClearLine(int y) {
+    SetCursorPosition(0, y);
+    Print(std::string(console_width_, ' '), Color::White);
+    SetCursorPosition(0, y);
+}
+
+void TerminalUI::SetTitle(const std::string& title) {
+    SetConsoleTitleA(title.c_str());
 }
 
 void TerminalUI::SetColor(Color color) {
@@ -191,6 +216,40 @@ std::string TerminalUI::FormatNumber(uint64_t number) {
     }
     
     return formatted;
+}
+
+// Spinner implementation
+Spinner::Spinner(TerminalUI* ui) : ui_(ui), running_(false) {}
+
+Spinner::~Spinner() {
+    Stop();
+}
+
+void Spinner::Start(const std::string& message) {
+    if (running_) return;
+    running_ = true;
+    thread_ = std::thread(&Spinner::Run, this, message);
+}
+
+void Spinner::Run(std::string message) {
+    const char* frames = "|/-\\";
+    size_t index = 0;
+    int line = ui_->GetHeight() - 2;
+    while (running_) {
+        ui_->SetCursorPosition(0, line);
+        ui_->Print(message + " " + frames[index % 4], Color::Bright_Cyan);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        index++;
+    }
+    ui_->ClearLine(line);
+}
+
+void Spinner::Stop() {
+    if (!running_) return;
+    running_ = false;
+    if (thread_.joinable()) {
+        thread_.join();
+    }
 }
 
 // FuzzingStatsDisplay implementation

--- a/src/cli_ui.h
+++ b/src/cli_ui.h
@@ -7,6 +7,8 @@
 #include <windows.h>
 #include <iostream>
 #include <sstream>
+#include <thread>
+#include <atomic>
 
 namespace winuzzf {
 namespace cli {
@@ -66,6 +68,8 @@ public:
     void HideCursor();
     void ShowCursor();
     void SetCursorPosition(int x, int y);
+    void ClearLine(int y);
+    void SetTitle(const std::string& title);
     void SetColor(Color color);
     void ResetColor();
     
@@ -102,6 +106,22 @@ private:
     int console_height_;
     
     void UpdateConsoleSize();
+};
+
+// Simple animated spinner for long running operations
+class Spinner {
+public:
+    explicit Spinner(TerminalUI* ui);
+    ~Spinner();
+
+    void Start(const std::string& message);
+    void Stop();
+
+private:
+    void Run(std::string message);
+    TerminalUI* ui_;
+    std::thread thread_;
+    std::atomic<bool> running_;
 };
 
 // Real-time fuzzing stats display

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,6 +151,7 @@ MutationStrategy ParseMutationStrategy(const std::string& strategy) {
 int main(int argc, char* argv[]) {
     // Initialize UI first
     g_ui = std::make_unique<cli::TerminalUI>();
+    g_ui->SetTitle("WinFuzz - Advanced Windows Fuzzing Framework");
     
     // Show banner
     PrintBanner();
@@ -210,9 +211,12 @@ int main(int argc, char* argv[]) {
         g_stats = std::make_unique<cli::FuzzingStatsDisplay>(g_ui.get());
         
         g_ui->PrintInfo("Initializing fuzzer...");
-        
+
+        cli::Spinner spinner(g_ui.get());
+        spinner.Start("Setting up");
         // Create fuzzer instance
         g_fuzzer = WinFuzzer::Create();
+        spinner.Stop();
         
         // Configure fuzzer
         FuzzConfig fuzz_config;


### PR DESCRIPTION
## Summary
- add spinner class and window title support to TerminalUI for a friendlier console experience
- replace `cls` with Windows console API to clear screen and allow clearing individual lines
- show spinner during fuzzer initialization and set window title on startup

## Testing
- `cmake -S . -B build` *(fails: This project is designed for Windows only)*

------
https://chatgpt.com/codex/tasks/task_e_68a7832d01848322ae40206bc86e7602