### PR TITLE
feat: auto-load default dictionary and expand corpus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ crashes/*
 crashes_*/
 corpus/*
 !corpus/.gitkeep
+!corpus/sample_*
 corpus_*/
 *.log
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A comprehensive, high-performance fuzzing framework specifically designed for Wi
 - **Crash Analysis**: Automatic exploitability assessment and deduplication
 - **High Performance**: Multi-threaded execution with optimized corpus management
 - **Comprehensive Reporting**: Detailed logs and final analysis reports
+- **Auto-Loading Resources**: Automatically loads `corpus/` and `dictionary.txt` when present
 
 ## 🎯 Quick Start
 
@@ -18,6 +19,7 @@ A comprehensive, high-performance fuzzing framework specifically designed for Wi
 ```bash
 winuzzf --target-api kernel32.dll CreateFileW --corpus corpus --crashes crashes
 ```
+Sample seed inputs are available in the `corpus/` directory.
 
 ### Driver Fuzzing
 ```bash
@@ -28,6 +30,7 @@ winuzzf --target-driver \\.\MyDriver --ioctl 0x220000 --coverage intel-pt
 ```bash
 winuzzf --target-exe notepad.exe --dict dictionary.txt --seed sample.txt
 ```
+If `--dict` is not specified, WinFuzz will automatically load `dictionary.txt` from the current directory when it exists.
 
 ## Architecture
 

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -74,7 +74,7 @@ winuzzf/
 ├── tools/                      # Utility tools
 ├── tests/                      # Unit tests
 ├── config.json                 # Configuration file
-├── dictionary.txt              # Fuzzing dictionary
+├── dictionary.txt              # Fuzzing dictionary (auto-loaded if present)
 └── README.md                   # Main documentation
 ```
 
@@ -186,6 +186,7 @@ fuzzer->Start();
     }
 }
 ```
+If `dict_file` is omitted, WinFuzz automatically attempts to load `dictionary.txt` from the current directory.
 
 ### Coverage Types
 

--- a/config_template.conf
+++ b/config_template.conf
@@ -31,8 +31,8 @@ coverage_type = none
 # Mutation Configuration
 # mutation_strategy = random|deterministic|dictionary|havoc|splice
 mutation_strategy = random
-dict_file = 
-seed_files = 
+dict_file =                # optional, loads dictionary.txt by default
+seed_files =
 
 # Optimization Configuration
 minimize_corpus = true

--- a/corpus/sample_http_request.txt
+++ b/corpus/sample_http_request.txt
@@ -1,0 +1,5 @@
+GET / HTTP/1.1
+Host: example.com
+User-Agent: WinFuzz
+Connection: close
+

--- a/corpus/sample_path.txt
+++ b/corpus/sample_path.txt
@@ -1,0 +1,1 @@
+C:\Windows\win.ini

--- a/dictionary.txt
+++ b/dictionary.txt
@@ -23,6 +23,11 @@ C:\Temp\
 .bin
 .cfg
 .ini
+.xml
+.json
+.html
+.doc
+.pdf
 
 # Windows device names
 CON
@@ -82,6 +87,8 @@ HKEY_CURRENT_CONFIG
 SOFTWARE
 SYSTEM
 HARDWARE
+SECURITY
+SAM
 
 # Common registry keys
 Microsoft
@@ -98,6 +105,10 @@ localhost
 255.255.255.255
 ::1
 ::
+http://
+https://
+ftp://
+file://
 
 # Common sizes (little endian)
 \x00\x00\x00\x00
@@ -147,3 +158,28 @@ administrator
 \xFF\xFE
 \xFE\xFF
 \xEF\xBB\xBF
+
+# Environment variables
+%SYSTEMROOT%
+%WINDIR%
+%TEMP%
+%TMP%
+%APPDATA%
+%PROGRAMDATA%
+%USERNAME%
+%COMPUTERNAME%
+%PATH%
+
+# Common file names
+desktop.ini
+Thumbs.db
+pagefile.sys
+ntuser.dat
+
+# Registry data types
+REG_SZ
+REG_DWORD
+REG_QWORD
+REG_BINARY
+REG_EXPAND_SZ
+REG_MULTI_SZ

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,13 +291,14 @@ int main(int argc, char* argv[]) {
         g_ui->PrintInfo("Using mutation strategy: " + config.mutation_strategy);
         g_fuzzer->AddMutationStrategy(ParseMutationStrategy(config.mutation_strategy));
         
-        // Load dictionary if provided
-        if (!config.dict_file.empty()) {
-            g_ui->PrintInfo("Loading dictionary: " + config.dict_file);
+        // Load dictionary if provided or default exists
+        std::string dict_file = config.dict_file.empty() ? "dictionary.txt" : config.dict_file;
+        if (std::filesystem::exists(dict_file)) {
+            g_ui->PrintInfo("Loading dictionary: " + dict_file);
             try {
-                auto dict_data = utils::ReadFile(config.dict_file);
+                auto dict_data = utils::ReadFile(dict_file);
                 std::string dict_str(dict_data.begin(), dict_data.end());
-                
+
                 // Simple dictionary parsing (one entry per line)
                 std::vector<std::string> dictionary;
                 std::istringstream iss(dict_str);
@@ -307,12 +308,14 @@ int main(int argc, char* argv[]) {
                         dictionary.push_back(line);
                     }
                 }
-                
+
                 g_fuzzer->SetDictionary(dictionary);
                 g_ui->PrintSuccess("Loaded " + std::to_string(dictionary.size()) + " dictionary entries");
             } catch (const std::exception& e) {
                 g_ui->PrintWarning("Failed to load dictionary: " + std::string(e.what()));
             }
+        } else if (!config.dict_file.empty()) {
+            g_ui->PrintWarning("Dictionary file not found: " + dict_file);
         }
         
         // Load seed files


### PR DESCRIPTION
## Summary
- auto-load `dictionary.txt` when no dict option is provided
- broaden built-in dictionary with env variables, network schemes, file names, and registry types
- add sample corpus seeds and allow them through `.gitignore`

## Testing
- `bash build.sh` *(fails: This project is designed for Windows only)*

------
https://chatgpt.com/codex/tasks/task_e_68a785318d448322aa4da5e68b00c9d5