### PR TITLE
Add portable build support and Linux-friendly stubs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-# Platform checks
-if(NOT WIN32)
-    message(FATAL_ERROR "This project is designed for Windows only")
-endif()
-
 # Compiler flags
 if(MSVC)
     add_compile_options(/W4 /permissive- /Zc:__cplusplus)
@@ -65,17 +60,19 @@ target_link_libraries(winuzzf
 )
 
 # Link Windows libraries
-target_link_libraries(winuzzf
-    kernel32
-    user32
-    advapi32
-    dbghelp
-    psapi
-    ntdll
-    wintrust
-    crypt32
-    bcrypt
-)
+if(WIN32)
+    target_link_libraries(winuzzf
+        kernel32
+        user32
+        advapi32
+        dbghelp
+        psapi
+        ntdll
+        wintrust
+        crypt32
+        bcrypt
+    )
+endif()
 
 # Install targets
 install(TARGETS winuzzf DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ cmake .. -G "Visual Studio 16 2019" -A x64
 cmake --build . --config Release
 ```
 
+### Building on Linux or WSL
+
+While WinFuzz's advanced instrumentation is Windows-focused, the project now builds on Linux and WSL with portable stubs so you can explore the codebase, run unit tests, and use the corpus utilities without a Windows SDK.
+
+```bash
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build
+```
+
+> **Note:** Non-Windows builds provide simplified implementations for Windows-specific functionality (sandboxing, ETW coverage, crash analysis, etc.). These stubs are ideal for development and CI but do not offer real instrumentation on Linux.
+
 ## Quick Start
 
 ### Basic API Fuzzing Example

--- a/examples/api_fuzzing_example.cpp
+++ b/examples/api_fuzzing_example.cpp
@@ -1,14 +1,20 @@
 #include "winuzzf.h"
-#include <iostream>
-#include <windows.h>
-#include <thread>
 #include <chrono>
+#include <iostream>
+#include <thread>
+#ifdef _WIN32
+#    include <windows.h>
+#endif
 
 using namespace winuzzf;
 
 int main() {
+#ifndef _WIN32
+    std::cout << "WinFuzz API example is only available on Windows." << std::endl;
+    return 0;
+#else
     std::cout << "WinFuzz API Fuzzing Example - CreateFileW" << std::endl;
-    
+
     try {
         // Create fuzzer instance
         auto fuzzer = WinFuzzer::Create();
@@ -134,6 +140,7 @@ int main() {
         std::cerr << "Error: " << e.what() << std::endl;
         return 1;
     }
-    
+
     return 0;
+#endif
 }

--- a/examples/driver_fuzzing_example.cpp
+++ b/examples/driver_fuzzing_example.cpp
@@ -1,14 +1,20 @@
 #include "winuzzf.h"
-#include <iostream>
-#include <windows.h>
-#include <thread>
 #include <chrono>
+#include <iostream>
+#include <thread>
+#ifdef _WIN32
+#    include <windows.h>
+#endif
 
 using namespace winuzzf;
 
 int main() {
+#ifndef _WIN32
+    std::cout << "WinFuzz driver example is only available on Windows." << std::endl;
+    return 0;
+#else
     std::cout << "WinFuzz Driver Fuzzing Example" << std::endl;
-    
+
     try {
         // Create fuzzer instance
         auto fuzzer = WinFuzzer::Create();
@@ -143,6 +149,7 @@ int main() {
         std::cerr << "Note: Driver fuzzing requires the target driver to be installed and accessible" << std::endl;
         return 1;
     }
-    
+
     return 0;
+#endif
 }

--- a/include/winuzzf.h
+++ b/include/winuzzf.h
@@ -5,7 +5,46 @@
 #include <vector>
 #include <functional>
 #include <cstdint>
-#include <windows.h>
+
+#ifdef _WIN32
+#    include <windows.h>
+#else
+#    include <cstddef>
+
+using HANDLE = void*;
+using DWORD = std::uint32_t;
+using SIZE_T = std::size_t;
+using HMODULE = void*;
+using FARPROC = void (*)();
+using BOOL = int;
+using BYTE = unsigned char;
+using WORD = std::uint16_t;
+using LONG = long;
+using PVOID = void*;
+using ULONG = unsigned long;
+using ULONGLONG = unsigned long long;
+using TRACEHANDLE = std::uint64_t;
+
+struct CONTEXT {
+    std::uint64_t Rip = 0;
+    std::uint64_t Rsp = 0;
+};
+
+struct EXCEPTION_POINTERS;
+using PEXCEPTION_POINTERS = EXCEPTION_POINTERS*;
+using LPTOP_LEVEL_EXCEPTION_FILTER = LONG (*)(PEXCEPTION_POINTERS);
+
+constexpr HANDLE INVALID_HANDLE_VALUE = nullptr;
+constexpr DWORD STILL_ACTIVE = 259;
+
+#    ifndef WINAPI
+#        define WINAPI
+#    endif
+
+#    ifndef MAX_PATH
+#        define MAX_PATH 260
+#    endif
+#endif
 
 namespace winuzzf {
 

--- a/src/cli_ui.h
+++ b/src/cli_ui.h
@@ -4,7 +4,9 @@
 #include <chrono>
 #include <memory>
 #include <vector>
-#include <windows.h>
+#ifdef _WIN32
+#    include <windows.h>
+#endif
 #include <iostream>
 #include <sstream>
 #include <thread>
@@ -101,14 +103,19 @@ public:
     std::string FormatNumber(uint64_t number);
 
 private:
+    int spinner_index_;
+#ifdef _WIN32
     HANDLE console_handle_;
     CONSOLE_SCREEN_BUFFER_INFO original_info_;
+#else
+    Color original_color_;
+#endif
     int console_width_;
     int console_height_;
-    int spinner_index_;
-    static inline const char kSpinnerFrames[4] = {'|', '/', '-', '\'};
+    static inline const char kSpinnerFrames[4] = {'|', '/', '-', static_cast<char>(92)};
 
     void UpdateConsoleSize();
+    void ApplyColor(Color color);
 };
 
 // Simple animated spinner for long running operations

--- a/src/corpus/CMakeLists.txt
+++ b/src/corpus/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_library(winuzzf_corpus STATIC
+    corpus_manager.cpp
+    corpus_manager.h
+)
+
+target_include_directories(winuzzf_corpus PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src
+)

--- a/src/corpus/corpus_manager.cpp
+++ b/src/corpus/corpus_manager.cpp
@@ -1,0 +1,105 @@
+#include "corpus_manager.h"
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+
+namespace winuzzf {
+
+namespace {
+std::vector<uint8_t> ReadAllBytes(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+        return {};
+    }
+    return std::vector<uint8_t>(std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>());
+}
+}
+
+CorpusManager::CorpusManager()
+    : corpus_dir_("corpus")
+    , minimize_(true)
+    , rng_(std::random_device{}()) {}
+
+void CorpusManager::SetCorpusDirectory(const std::string& dir) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    corpus_dir_ = dir;
+}
+
+void CorpusManager::SetMinimizationEnabled(bool enabled) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    minimize_ = enabled;
+    (void)minimize_;
+}
+
+void CorpusManager::AddInput(const std::vector<uint8_t>& input) {
+    if (input.empty()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    corpus_.push_back(input);
+}
+
+void CorpusManager::LoadFromDirectory(const std::string& dir) {
+    std::filesystem::path directory = dir.empty() ? corpus_dir_ : dir;
+    if (directory.empty() || !std::filesystem::exists(directory)) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& entry : std::filesystem::directory_iterator(directory)) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        auto data = ReadAllBytes(entry.path());
+        if (!data.empty()) {
+            corpus_.push_back(std::move(data));
+        }
+    }
+}
+
+void CorpusManager::SaveToDirectory(const std::string& dir) const {
+    std::filesystem::path directory = dir.empty() ? corpus_dir_ : dir;
+    if (directory.empty()) {
+        return;
+    }
+
+    std::filesystem::create_directories(directory);
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::size_t index = 0;
+    for (const auto& input : corpus_) {
+        auto filename = directory / ("input_" + std::to_string(index++) + ".bin");
+        SaveInputToFile(filename.string(), input);
+    }
+}
+
+std::vector<std::vector<uint8_t>> CorpusManager::GetRandomInputs(std::size_t count) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::vector<uint8_t>> result;
+    if (corpus_.empty() || count == 0) {
+        return result;
+    }
+
+    std::uniform_int_distribution<std::size_t> dist(0, corpus_.size() - 1);
+    for (std::size_t i = 0; i < count; ++i) {
+        result.push_back(corpus_[dist(rng_)]);
+    }
+    return result;
+}
+
+std::size_t CorpusManager::GetCorpusSize() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return corpus_.size();
+}
+
+void CorpusManager::SaveInputToFile(const std::string& filename, const std::vector<uint8_t>& input) const {
+    std::ofstream file(filename, std::ios::binary | std::ios::trunc);
+    if (!file) {
+        return;
+    }
+    file.write(reinterpret_cast<const char*>(input.data()), static_cast<std::streamsize>(input.size()));
+}
+
+} // namespace winuzzf

--- a/src/corpus/corpus_manager.h
+++ b/src/corpus/corpus_manager.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include <mutex>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace winuzzf {
+
+class CorpusManager {
+public:
+    CorpusManager();
+
+    void SetCorpusDirectory(const std::string& dir);
+    void SetMinimizationEnabled(bool enabled);
+
+    void AddInput(const std::vector<uint8_t>& input);
+    void LoadFromDirectory(const std::string& dir);
+    void SaveToDirectory(const std::string& dir) const;
+
+    std::vector<std::vector<uint8_t>> GetRandomInputs(std::size_t count);
+    std::size_t GetCorpusSize() const;
+
+private:
+    std::string corpus_dir_;
+    bool minimize_;
+    mutable std::mutex mutex_;
+    std::vector<std::vector<uint8_t>> corpus_;
+    mutable std::mt19937 rng_;
+
+    void SaveInputToFile(const std::string& filename, const std::vector<uint8_t>& input) const;
+};
+
+} // namespace winuzzf

--- a/src/coverage/CMakeLists.txt
+++ b/src/coverage/CMakeLists.txt
@@ -8,6 +8,8 @@ target_include_directories(winuzzf_coverage PUBLIC
     ${CMAKE_SOURCE_DIR}/src
 )
 
-target_link_libraries(winuzzf_coverage
-    advapi32
-)
+if(WIN32)
+    target_link_libraries(winuzzf_coverage
+        advapi32
+    )
+endif()

--- a/src/coverage/coverage_collector.h
+++ b/src/coverage/coverage_collector.h
@@ -2,9 +2,18 @@
 
 #include "winuzzf.h"
 #include <memory>
-#include <unordered_set>
 #include <mutex>
-#include <windows.h>
+#include <unordered_set>
+#ifdef _WIN32
+#    include <windows.h>
+#else
+struct GUID {
+    unsigned long Data1 = 0;
+    unsigned short Data2 = 0;
+    unsigned short Data3 = 0;
+    unsigned char Data4[8] = {0};
+};
+#endif
 
 namespace winuzzf {
 

--- a/src/crash/CMakeLists.txt
+++ b/src/crash/CMakeLists.txt
@@ -8,7 +8,9 @@ target_include_directories(winuzzf_crash PUBLIC
     ${CMAKE_SOURCE_DIR}/src
 )
 
-target_link_libraries(winuzzf_crash
-    dbghelp
-    psapi
-)
+if(WIN32)
+    target_link_libraries(winuzzf_crash
+        dbghelp
+        psapi
+    )
+endif()

--- a/src/crash/crash_analyzer.h
+++ b/src/crash/crash_analyzer.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "winuzzf.h"
-#include <windows.h>
 #include <memory>
 #include <string>
 #include <vector>
 #include <mutex>
+#ifdef _WIN32
+#    include <windows.h>
+#endif
 
 namespace winuzzf {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -242,6 +242,7 @@ int main(int argc, char* argv[]) {
             
             // Set up common API parameter templates
             if (config.target_param2 == "CreateFileW") {
+#ifdef _WIN32
                 api_target->SetParameterTemplate({
                     sizeof(LPCWSTR),    // lpFileName
                     sizeof(DWORD),      // dwDesiredAccess
@@ -251,6 +252,17 @@ int main(int argc, char* argv[]) {
                     sizeof(DWORD),      // dwFlagsAndAttributes
                     sizeof(HANDLE)      // hTemplateFile
                 });
+#else
+                api_target->SetParameterTemplate({
+                    sizeof(uintptr_t),
+                    sizeof(uint32_t),
+                    sizeof(uint32_t),
+                    sizeof(uintptr_t),
+                    sizeof(uint32_t),
+                    sizeof(uint32_t),
+                    sizeof(uintptr_t)
+                });
+#endif
             }
             
             target = api_target;

--- a/src/mutators/mutator.cpp
+++ b/src/mutators/mutator.cpp
@@ -1,6 +1,7 @@
 #include "mutator.h"
 #include <algorithm>
 #include <cassert>
+#include <cstring>
 
 namespace winuzzf {
 

--- a/src/sandbox/sandbox.cpp
+++ b/src/sandbox/sandbox.cpp
@@ -1,25 +1,27 @@
 #include "sandbox.h"
 #include <iostream>
+#include <stdexcept>
 
 namespace winuzzf {
+
+#ifdef _WIN32
 
 class Sandbox::Impl {
 public:
     Impl() : initialized_(false) {}
-    
+
     bool Initialize() {
         if (initialized_) return true;
-        
-        // Create default job object for sandboxing
+
         job_sandbox_ = std::make_unique<JobObjectSandbox>();
         if (!job_sandbox_->Create("WinFuzzSandbox")) {
             return false;
         }
-        
+
         initialized_ = true;
         return true;
     }
-    
+
     void Cleanup() {
         if (job_sandbox_) {
             job_sandbox_->Terminate();
@@ -27,15 +29,14 @@ public:
         }
         initialized_ = false;
     }
-    
+
     HANDLE CreateSandboxedProcess(const std::string& command_line) {
         if (!initialized_) return nullptr;
-        
+
         STARTUPINFOA si = {};
         PROCESS_INFORMATION pi = {};
         si.cb = sizeof(si);
-        
-        // Create suspended process
+
         BOOL result = CreateProcessA(
             nullptr,
             const_cast<char*>(command_line.c_str()),
@@ -48,99 +49,82 @@ public:
             &si,
             &pi
         );
-        
+
         if (!result) {
             return nullptr;
         }
-        
-        // Assign to job object
+
         if (!job_sandbox_->AssignProcess(pi.hProcess)) {
             TerminateProcess(pi.hProcess, 0);
             CloseHandle(pi.hProcess);
             CloseHandle(pi.hThread);
             return nullptr;
         }
-        
-        // Enable security features
+
         EnableDEP(pi.hProcess);
         EnableASLR(pi.hProcess);
-        
-        // Resume main thread
+
         ResumeThread(pi.hThread);
         CloseHandle(pi.hThread);
-        
+
         return pi.hProcess;
     }
-    
+
     bool TerminateProcess(HANDLE process_handle, DWORD timeout_ms) {
         if (!process_handle || process_handle == INVALID_HANDLE_VALUE) {
             return false;
         }
-        
-        // Try graceful termination first
+
         if (::TerminateProcess(process_handle, 1)) {
-            // Wait for process to exit
             DWORD wait_result = WaitForSingleObject(process_handle, timeout_ms);
             return wait_result == WAIT_OBJECT_0;
         }
-        
+
         return false;
     }
-    
+
     bool IsProcessAlive(HANDLE process_handle) {
         if (!process_handle || process_handle == INVALID_HANDLE_VALUE) {
             return false;
         }
-        
-        DWORD exit_code;
+
+        DWORD exit_code = 0;
         if (GetExitCodeProcess(process_handle, &exit_code)) {
             return exit_code == STILL_ACTIVE;
         }
-        
+
         return false;
     }
-    
+
     void EnableDEP(HANDLE process_handle) {
-        // DEP is usually enabled by default on modern Windows
-        // This is a placeholder for explicit DEP configuration
-        
-        typedef BOOL (WINAPI *SetProcessDEPPolicyProc)(DWORD dwFlags);
+        typedef BOOL(WINAPI *SetProcessDEPPolicyProc)(DWORD dwFlags);
         HMODULE kernel32 = GetModuleHandleA("kernel32.dll");
         if (kernel32) {
-            SetProcessDEPPolicyProc SetProcessDEPPolicy = 
+            auto SetProcessDEPPolicy =
                 reinterpret_cast<SetProcessDEPPolicyProc>(GetProcAddress(kernel32, "SetProcessDEPPolicy"));
             if (SetProcessDEPPolicy) {
                 SetProcessDEPPolicy(PROCESS_DEP_ENABLE);
             }
         }
     }
-    
-    void EnableASLR(HANDLE process_handle) {
-        // ASLR is enabled by linker flags and system settings
-        // This is a placeholder for runtime ASLR configuration
-    }
-    
-    void SetHeapFlags(HANDLE process_handle, DWORD flags) {
-        // Set heap flags for the target process
-        // This would require more advanced process manipulation
-    }
-    
-    void SetMemoryLimit(HANDLE process_handle, SIZE_T limit_bytes) {
+
+    void EnableASLR(HANDLE) {}
+
+    void SetHeapFlags(HANDLE, DWORD) {}
+
+    void SetMemoryLimit(HANDLE, SIZE_T limit_bytes) {
         if (job_sandbox_) {
             job_sandbox_->SetLimits(limit_bytes, 0);
         }
     }
-    
-    void SetTimeLimit(HANDLE process_handle, DWORD limit_ms) {
+
+    void SetTimeLimit(HANDLE, DWORD limit_ms) {
         if (job_sandbox_) {
             job_sandbox_->SetLimits(0, limit_ms);
         }
     }
-    
-    void SetCpuLimit(HANDLE process_handle, DWORD percentage) {
-        // CPU limiting would be implemented through job objects
-        // or process priority manipulation
-    }
+
+    void SetCpuLimit(HANDLE, DWORD) {}
 
 private:
     bool initialized_;
@@ -194,7 +178,6 @@ void Sandbox::SetCpuLimit(HANDLE process_handle, DWORD percentage) {
     pImpl->SetCpuLimit(process_handle, percentage);
 }
 
-// Job Object Sandbox Implementation
 JobObjectSandbox::JobObjectSandbox() : job_handle_(nullptr) {}
 
 JobObjectSandbox::~JobObjectSandbox() {
@@ -203,25 +186,24 @@ JobObjectSandbox::~JobObjectSandbox() {
 
 bool JobObjectSandbox::Create(const std::string& job_name) {
     job_name_ = job_name;
-    
+
     job_handle_ = CreateJobObjectA(nullptr, job_name.c_str());
     if (!job_handle_) {
         std::cerr << "Failed to create job object: " << GetLastError() << std::endl;
         return false;
     }
-    
-    // Set basic limits
+
     JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_limits = {};
-    job_limits.BasicLimitInformation.LimitFlags = 
+    job_limits.BasicLimitInformation.LimitFlags =
         JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE |
         JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION;
-    
-    if (!SetInformationJobObject(job_handle_, JobObjectExtendedLimitInformation, 
-                                &job_limits, sizeof(job_limits))) {
+
+    if (!SetInformationJobObject(job_handle_, JobObjectExtendedLimitInformation,
+                                 &job_limits, sizeof(job_limits))) {
         std::cerr << "Failed to set job object limits: " << GetLastError() << std::endl;
         return false;
     }
-    
+
     return true;
 }
 
@@ -229,31 +211,31 @@ bool JobObjectSandbox::AssignProcess(HANDLE process_handle) {
     if (!job_handle_ || !process_handle) {
         return false;
     }
-    
+
     return AssignProcessToJobObject(job_handle_, process_handle) != FALSE;
 }
 
 void JobObjectSandbox::SetLimits(SIZE_T memory_limit, DWORD time_limit) {
     if (!job_handle_) return;
-    
+
     JOBOBJECT_EXTENDED_LIMIT_INFORMATION job_limits = {};
-    DWORD limit_flags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | 
+    DWORD limit_flags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE |
                        JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION;
-    
+
     if (memory_limit > 0) {
         job_limits.ProcessMemoryLimit = memory_limit;
         limit_flags |= JOB_OBJECT_LIMIT_PROCESS_MEMORY;
     }
-    
+
     if (time_limit > 0) {
-        job_limits.BasicLimitInformation.PerProcessUserTimeLimit.QuadPart = 
-            static_cast<LONGLONG>(time_limit) * 10000; // Convert ms to 100ns units
+        job_limits.BasicLimitInformation.PerProcessUserTimeLimit.QuadPart =
+            static_cast<LONGLONG>(time_limit) * 10000;
         limit_flags |= JOB_OBJECT_LIMIT_PROCESS_TIME;
     }
-    
+
     job_limits.BasicLimitInformation.LimitFlags = limit_flags;
-    
-    SetInformationJobObject(job_handle_, JobObjectExtendedLimitInformation, 
+
+    SetInformationJobObject(job_handle_, JobObjectExtendedLimitInformation,
                            &job_limits, sizeof(job_limits));
 }
 
@@ -265,4 +247,59 @@ void JobObjectSandbox::Terminate() {
     }
 }
 
+#else // _WIN32
+
+class Sandbox::Impl {};
+
+Sandbox::Sandbox() : pImpl(std::make_unique<Impl>()) {}
+Sandbox::~Sandbox() = default;
+
+bool Sandbox::Initialize() {
+    return true;
+}
+
+void Sandbox::Cleanup() {}
+
+HANDLE Sandbox::CreateSandboxedProcess(const std::string&) {
+    throw std::runtime_error("Process sandboxing is only supported on Windows builds.");
+}
+
+bool Sandbox::TerminateProcess(HANDLE, DWORD) {
+    return false;
+}
+
+bool Sandbox::IsProcessAlive(HANDLE) {
+    return false;
+}
+
+void Sandbox::EnableDEP(HANDLE) {}
+
+void Sandbox::EnableASLR(HANDLE) {}
+
+void Sandbox::SetHeapFlags(HANDLE, DWORD) {}
+
+void Sandbox::SetMemoryLimit(HANDLE, SIZE_T) {}
+
+void Sandbox::SetTimeLimit(HANDLE, DWORD) {}
+
+void Sandbox::SetCpuLimit(HANDLE, DWORD) {}
+
+JobObjectSandbox::JobObjectSandbox() = default;
+JobObjectSandbox::~JobObjectSandbox() = default;
+
+bool JobObjectSandbox::Create(const std::string&) {
+    return false;
+}
+
+bool JobObjectSandbox::AssignProcess(HANDLE) {
+    return false;
+}
+
+void JobObjectSandbox::SetLimits(SIZE_T, DWORD) {}
+
+void JobObjectSandbox::Terminate() {}
+
+#endif // _WIN32
+
 } // namespace winuzzf
+

--- a/src/sandbox/sandbox.h
+++ b/src/sandbox/sandbox.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "winuzzf.h"
-#include <windows.h>
 #include <memory>
 #include <string>
+#ifdef _WIN32
+#    include <windows.h>
+#endif
 
 namespace winuzzf {
 


### PR DESCRIPTION
## Summary
- add portable stubs so WinFuzz builds on Linux/WSL while retaining Windows functionality under `_WIN32`
- provide a corpus manager implementation and update build system plus examples to accommodate cross-platform builds
- refresh README and CLI to document Linux support and offer ANSI-friendly terminal behavior

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68ca376a86e083229f66db434d0f0dbb